### PR TITLE
Fix: Play/Pause button styles do not match their action

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -226,8 +226,8 @@ body {
     border-color: transparent transparent transparent #202020;
     transition: 100ms all ease;
     cursor: pointer;
-    border-style: double;
-    border-width: 0 0 0 120px;
+    border-style: solid;
+    border-width: 75px 75px 75px 120px;
 }
 
 .playpause input[type="checkbox"] {
@@ -235,8 +235,8 @@ body {
 }
 
 .playpause input[type="checkbox"]:checked + label {
-    border-style: solid;
-    border-width: 75px 75px 75px 120px;
+    border-style: double;
+    border-width: 0 0 0 120px;
 }
 
 .separator {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -198,11 +198,11 @@
         function updatePlayPauseLabel() {
             let playpauseLabel = document.getElementById('playpauseLabel');
             if (timerRunning) {
-                playpauseLabel.style.borderStyle = 'solid';
-                playpauseLabel.style.borderWidth = '37px 0 37px 60px';
-            } else {
                 playpauseLabel.style.borderStyle = 'double';
-                playpauseLabel.style.borderWidth = '0 0 0 60px';
+                playpauseLabel.style.borderWidth = '0 0 0 120px';
+            } else {
+                playpauseLabel.style.borderStyle = 'solid';
+                playpauseLabel.style.borderWidth = '75px 75px 75px 120px';
             }
         }
     </script>


### PR DESCRIPTION
The styles applied to the playpause button were presented in reverse when compared to their actions. CSS and the `updatePlayPauseLabel()` function have been adjusted accordingly.

This fixes #3 