### PR TITLE
Chore: Add /venv directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/__pycache__/
+/venv


### PR DESCRIPTION
Python virtual environments are unique to the hosts they are created and should be ignored when committing changes to the code base.

This fixes #6 